### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jvm-ci.yml
+++ b/.github/workflows/jvm-ci.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "tools-jvm/**"
 
+permissions:
+  contents: read
+
 jobs:
   jvm-ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/62](https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/62)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the provided workflow, it appears that the workflow only needs to read repository contents and does not require write access. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
