### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -1,4 +1,6 @@
 name: deno-ci
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/61](https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/61)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and runs Deno commands (lint, format, test) without making any changes to the repository or interacting with issues or pull requests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` field. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
