### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,5 +1,8 @@
 name: nodejs-ci
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/60](https://github.com/vighnesh153/vighnesh153-monorepo/security/code-scanning/60)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow primarily involves reading repository contents and does not require write access, the permissions should be set to `contents: read`. This change ensures that the workflow adheres to the principle of least privilege and avoids potential security risks.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
